### PR TITLE
chore: tweaking code climate to report on areas we actually care about

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,10 @@
+checks:
+  similar-code:
+    enabled: false
+  identical-code:
+    enabled: false
+  method-lines:
+    enabled: false
 exclude_patterns:
 - "**/*.spec.*"
 - "examples/**/*"


### PR DESCRIPTION
## SUMMARY:

In the case of reporters it is expected that there will always be some duplication. Additionally method-line length is not something interesting to report on at this point as it simply favors more abstraction than we currently need.

Note: other default options like method-complexity and file-lines are being left alone (default enabled) since they are useful when refactoring.