### PR TITLE
Feature/add network tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [1.2.0](https://github.com/Jmsa/bleed-guard/compare/v1.1.0...v1.2.0) (2024-12-05)
+
+
+### Features
+
+* add basic network request tracking ([4ae6474](https://github.com/Jmsa/bleed-guard/commit/4ae647457279bef2287fd9eea36a6607eadfbec4))
+
 ## [1.1.0](https://github.com/Jmsa/bleed-guard/compare/v1.0.0...v1.1.0) (2024-10-03)
 
 

--- a/detection.spec.ts
+++ b/detection.spec.ts
@@ -91,7 +91,6 @@ describe("detection", () => {
         },
         "./"
       );
-
       detectBleed({ logLevel: "none" });
       expect(consoleSpy).toHaveBeenCalledTimes(0);
     });
@@ -104,7 +103,6 @@ describe("detection", () => {
         },
         "./"
       );
-
       detectBleed({ logLevel: "none" });
       expect(consoleSpy).toHaveBeenCalledTimes(0);
     });
@@ -124,6 +122,7 @@ describe("detection", () => {
         `[BleedGuard]: See the temp output (./bleed-guard-test-bleed.json) for details or run with the 'verbose' reporter option enabled`
       );
     });
+
     it("logs when there is dom bleed", () => {
       const consoleSpy = jest
         .spyOn(console, "log")
@@ -163,6 +162,29 @@ describe("detection", () => {
       expect(consoleSpy).toHaveBeenNthCalledWith(
         1,
         `[BleedGuard]: Window bleed detected!`
+      );
+      expect(consoleSpy).toHaveBeenNthCalledWith(
+        2,
+        `[BleedGuard]: See the temp output (./bleed-guard-test-bleed.json) for details or run with the 'verbose' reporter option enabled`
+      );
+    });
+
+    it("logs when there is network bleed", () => {
+      const consoleSpy = jest
+        .spyOn(console, "log")
+        .mockImplementation(() => {});
+      vol.fromJSON({
+        [filePaths.testBleed]: JSON.stringify(
+          { network: testBleedResults.network },
+          null,
+          4
+        ),
+      });
+      detectBleed({ logLevel: "info" });
+      expect(consoleSpy).toHaveBeenCalledTimes(2);
+      expect(consoleSpy).toHaveBeenNthCalledWith(
+        1,
+        `[BleedGuard]: Network requests still pending!`
       );
       expect(consoleSpy).toHaveBeenNthCalledWith(
         2,
@@ -211,6 +233,26 @@ describe("detection", () => {
       );
       expect(consoleSpy).toHaveBeenNthCalledWith(2, testBleedResults.window);
     });
+
+    it("logs when there is network bleed", () => {
+      const consoleSpy = jest
+        .spyOn(console, "log")
+        .mockImplementation(() => {});
+      vol.fromJSON({
+        [filePaths.testBleed]: JSON.stringify(
+          { network: testBleedResults.network },
+          null,
+          4
+        ),
+      });
+      detectBleed({ logLevel: "verbose" });
+      expect(consoleSpy).toHaveBeenCalledTimes(2);
+      expect(consoleSpy).toHaveBeenNthCalledWith(
+        1,
+        `[BleedGuard]: Network requests still pending!`
+      );
+      expect(consoleSpy).toHaveBeenNthCalledWith(2, testBleedResults.network);
+    });
   });
 
   describe("throws when shouldThrow is true", () => {
@@ -229,6 +271,7 @@ describe("detection", () => {
         detectBleed({ logLevel: "info", shouldThrow: true })
       ).toThrow("[BleedGuard]: Test bleed detected!!! See output for details.");
     });
+
     it("and there is window bleed", () => {
       const consoleSpy = jest
         .spyOn(console, "log")
@@ -236,6 +279,22 @@ describe("detection", () => {
       vol.fromJSON({
         [filePaths.testBleed]: JSON.stringify(
           { window: testBleedResults.window },
+          null,
+          4
+        ),
+      });
+      expect(() =>
+        detectBleed({ logLevel: "info", shouldThrow: true })
+      ).toThrow("[BleedGuard]: Test bleed detected!!! See output for details.");
+    });
+
+    it("and there is network bleed", () => {
+      const consoleSpy = jest
+        .spyOn(console, "log")
+        .mockImplementation(() => {});
+      vol.fromJSON({
+        [filePaths.testBleed]: JSON.stringify(
+          { network: testBleedResults.network },
           null,
           4
         ),
@@ -279,6 +338,15 @@ const testBleedResults = {
         "207": "dispatchEvent",
       },
       newKeys: ["button"],
+    },
+  ],
+  network: [
+    {
+      method: "GET",
+      url: "https://api.example.com/data",
+      headers: {
+        "Content-Type": "application/json",
+      },
     },
   ],
 };

--- a/detection.ts
+++ b/detection.ts
@@ -151,6 +151,8 @@ export const setup = (beforeAll, afterEach, afterAll) => {
   };
 
   // Track any open XMLHttpRequests or fetch requests
+  // These are the two most common ways that network requests are made in JS and should
+  // cover most cases. Node libraries may opt to use http however which would not be detected.
   const networkCheck = () => {
     const originalXHR = window.XMLHttpRequest;
     const originalFetch = window.fetch;
@@ -179,8 +181,6 @@ export const setup = (beforeAll, afterEach, afterAll) => {
       });
       return promise;
     } as any;
-
-    // TODO: sanity check the way packages like axios work
 
     cleanUp.push(() => {
       if (activeRequests.size > 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bleed-guard",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A collection of test reporters dedicated ot helping track, and stop, test bleed.",
   "repository": "https://github.com/Jmsa/bleed-guard.git",
   "author": "James Abercrombie <jmsabercrombie88@gmail.com>",


### PR DESCRIPTION
### SUMMARY:
- Add support for detecting pending network requests

Open network requests aren't always top of mind, but when they stick around, they can cause tests to bleed into each other unpredictably—and tracking them down can be a real time sink. This feature adds detection for open network requests to help catch these issues early and save debugging headaches.

### TESTING NOTES:
"The first principle is that you must not fool yourself, and you are the easiest person to fool."
- Fill in notes about your test approach -- discussion points:
  - [X] Unit tests at the `detection` level

### TODOs:
- [X] Follow up on axios/other-library request investigations - existing network detection should cover most cases
- [x] Bump version when ready to release (pre-merge)